### PR TITLE
[DEV-2590] Reverse proxy via cli

### DIFF
--- a/internal/pkg/api/tunnels.go
+++ b/internal/pkg/api/tunnels.go
@@ -30,6 +30,7 @@ func (rp *Rport) CreateTunnel(
 	clientID, local, remote, scheme, acl, checkPort string,
 	idleTimeoutMinutes int,
 	skipIdleTimeout bool,
+	useHTTPProxy bool,
 ) (tunResp *TunnelCreatedResponse, err error) {
 	var req *http.Request
 	u := strings.Replace(CreateTunnelURL, "{client_id}", clientID, 1)
@@ -49,6 +50,10 @@ func (rp *Rport) CreateTunnel(
 	q.Add("scheme", scheme)
 	q.Add("acl", acl)
 	q.Add("check_port", checkPort)
+
+	if useHTTPProxy {
+		q.Add("http_proxy", "true")
+	}
 
 	if idleTimeoutMinutes > 0 {
 		q.Add("idle-timeout-minutes", strconv.Itoa(idleTimeoutMinutes))

--- a/internal/pkg/api/tunnels_test.go
+++ b/internal/pkg/api/tunnels_test.go
@@ -55,6 +55,7 @@ func TestCreateTunnel(t *testing.T) {
 		"1",
 		0,
 		false,
+		false,
 	)
 	assert.NoError(t, err)
 	if err != nil {
@@ -69,6 +70,64 @@ func TestCreateTunnel(t *testing.T) {
 	assert.Equal(t, "3344", actualTunnel.Rport)
 	assert.Equal(t, utils.SSH, actualTunnel.Scheme)
 	assert.Equal(t, "127.0.0.1", actualTunnel.ACL)
+}
+
+func TestCreateTunnelWithHTTPProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Basic bG9nMWRmYWRmOnBhc3MxZGZhc2ZhZGY=", r.Header.Get("Authorization"))
+		assert.Equal(t, http.MethodPut, r.Method)
+
+		assert.Equal(t, "/api/v1/clients/1234567890/tunnels?acl=78.34.189.65&check_port=1&http_proxy=true&local=0.0.0.0%3A20793&remote=127.0.0.1%3A80&scheme=http", r.URL.String())
+		jsonEnc := json.NewEncoder(rw)
+		e := jsonEnc.Encode(TunnelResponse{Data: &models.Tunnel{
+			ID:          "10",
+			Lhost:       "0.0.0.0",
+			Lport:       "20793",
+			Rhost:       "127.0.0.1",
+			Rport:       "80",
+			LportRandom: true,
+			Scheme:      utils.HTTP,
+			ACL:         "78.34.189.65",
+		}})
+		assert.NoError(t, e)
+	}))
+	defer srv.Close()
+
+	apiAuth := &utils.StorageBasicAuth{
+		AuthProvider: func() (l, p string, err error) {
+			l = "log1dfadf"
+			p = "pass1dfasfadf"
+			return
+		},
+	}
+
+	cl := New(srv.URL, apiAuth)
+
+	clientsResp, err := cl.CreateTunnel(
+		context.Background(),
+		"1234567890",
+		"0.0.0.0:20793",
+		"127.0.0.1:80",
+		utils.HTTP,
+		"78.34.189.65",
+		"1",
+		0,
+		false,
+		true,
+	)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	actualTunnel := clientsResp.Data
+	assert.Equal(t, "10", actualTunnel.ID)
+	assert.Equal(t, "0.0.0.0", actualTunnel.Lhost)
+	assert.Equal(t, "20793", actualTunnel.Lport)
+	assert.Equal(t, "127.0.0.1", actualTunnel.Rhost)
+	assert.Equal(t, "80", actualTunnel.Rport)
+	assert.Equal(t, utils.HTTP, actualTunnel.Scheme)
+	assert.Equal(t, "78.34.189.65", actualTunnel.ACL)
 }
 
 func TestDeleteTunnel(t *testing.T) {

--- a/internal/pkg/config/flags_shared.go
+++ b/internal/pkg/config/flags_shared.go
@@ -38,6 +38,7 @@ const (
 	RDPUser            = "rdp-user"
 	DefaultACL         = "<<YOU CURRENT PUBLIC IP>>"
 	ForceDeletion      = "force"
+	UseHTTPProxy       = "http-proxy"
 
 	DefaultCmdTimeoutSeconds = 30
 )

--- a/internal/pkg/config/flags_tunnel.go
+++ b/internal/pkg/config/flags_tunnel.go
@@ -27,22 +27,8 @@ Any parameter passed are append to the ssh command. i.e. -b "-l root"`
 func GetCreateTunnelParamReqs(isRDPUserRequired bool) []ParameterRequirement {
 	return []ParameterRequirement{
 		GetNoPromptParamReq(),
-		{
-			Field:       ClientID,
-			Description: "[conditionally required] client id, if not provided, client name should be given",
-			Validate:    RequiredValidate,
-			ShortName:   "c",
-			IsRequired:  true,
-			IsEnabled: func(providedParams *options.ParameterBag) bool {
-				return providedParams.ReadString(ClientNameFlag, "") == ""
-			},
-			Help: "Enter a client ID",
-		},
-		{
-			Field:       ClientNameFlag,
-			Description: `client name, if no client id is provided`,
-			ShortName:   "n",
-		},
+		GetClientIDForTunnelParamReq(),
+		GetClientNameForTunnelParamReq(),
 		{
 			Field:       Local,
 			Description: CreateTunnelLocalDescr,
@@ -124,6 +110,12 @@ Optionally pass the rdp-width and rdp-height params for RDP window size`,
 			ShortName:   "m",
 			Type:        IntRequirementType,
 		},
+		{
+			Field:       UseHTTPProxy,
+			Description: "Use http or https proxy (note: -s or --scheme must be either http or https)",
+			Type:        BoolRequirementType,
+			Default:     false,
+		},
 	}
 }
 
@@ -175,5 +167,27 @@ func GetDeleteTunnelParamReqs() []ParameterRequirement {
 			Validate:    RequiredValidate,
 			Help:        "Enter a tunnel id",
 		},
+	}
+}
+
+func GetClientIDForTunnelParamReq() (paramReq ParameterRequirement) {
+	return ParameterRequirement{
+		Field:       ClientID,
+		Description: "[conditionally required] client id, if not provided, client name should be given",
+		Validate:    RequiredValidate,
+		ShortName:   "c",
+		IsRequired:  true,
+		IsEnabled: func(providedParams *options.ParameterBag) bool {
+			return providedParams.ReadString(ClientNameFlag, "") == ""
+		},
+		Help: "Enter a client ID",
+	}
+}
+
+func GetClientNameForTunnelParamReq() (paramReq ParameterRequirement) {
+	return ParameterRequirement{
+		Field:       ClientNameFlag,
+		Description: `client name, if no client id is provided`,
+		ShortName:   "n",
 	}
 }

--- a/internal/pkg/config/load.go
+++ b/internal/pkg/config/load.go
@@ -173,6 +173,13 @@ func CollectParamsFromCommandAndPromptAndEnv(
 		return nil, err
 	}
 
+	if HasHTTPProxy(paramsSoFar) {
+		isCorrect := checkCorrectSchemeForHTTPProxy(paramsSoFar)
+		if !isCorrect {
+			return nil, ErrInvalidSchemeForHTTPProxy
+		}
+	}
+
 	// if the no-prompt cli flag is set, then do not prompt for missing values
 	noPrompt := paramsSoFar.ReadBool(NoPrompt, false)
 	if noPrompt || promptReader == nil {

--- a/internal/pkg/controllers/tunnel_test.go
+++ b/internal/pkg/controllers/tunnel_test.go
@@ -251,7 +251,7 @@ func TestTunnelCreateWithClientID(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"123","client_id":"334","client_name":"","lhost":"lohost1","lport":"3300","rhost":"rhost2","rport":"3344","lport_random":true,"scheme":"ssh","acl":"3.4.5.6","usage":"ssh -p 3300 localhost.com -l ${USER}","idle_timeout_minutes":7,"rport_server":"%s"}`,
+		`{"id":"123","client_id":"334","lhost":"lohost1","lport":"3300","rhost":"rhost2","rport":"3344","lport_random":true,"scheme":"ssh","acl":"3.4.5.6","usage":"ssh -p 3300 localhost.com -l ${USER}","idle_timeout_minutes":7,"rport_server":"%s"}`,
 		srv.URL,
 	)
 	assert.Equal(t, expectedOutput, buf.String())
@@ -319,7 +319,7 @@ func TestTunnelCreateWithSchemeDiscovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"444","client_id":"32312","client_name":"","lhost":"lohost33","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh ya.ru -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"444","client_id":"32312","lhost":"lohost33","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh ya.ru -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 
@@ -380,7 +380,7 @@ func TestTunnelCreateWithPortDiscovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"777","client_id":"1313","client_name":"","lhost":"lohost44","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh some.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"777","client_id":"1313","lhost":"lohost44","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh some.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 
@@ -397,7 +397,7 @@ func TestTunnelCreateWithPortDiscovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput2 := fmt.Sprintf(
-		`{"id":"777","client_id":"1313","client_name":"","lhost":"lohost44","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh some.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}{"status":"Tunnel successfully deleted"}`,
+		`{"id":"777","client_id":"1313","lhost":"lohost44","lport":"","rhost":"","rport":"","lport_random":false,"scheme":"","acl":"","usage":"ssh some.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}{"status":"Tunnel successfully deleted"}`,
 		srv.URL,
 	)
 	assert.Equal(
@@ -469,7 +469,7 @@ func TestTunnelCreateWithSSH(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"777","client_id":"1314","client_name":"","lhost":"lohost77","lport":"22","rhost":"","rport":"","lport_random":false,"scheme":"ssh","acl":"","usage":"ssh -p 22 rport-url.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}{"status":"Tunnel successfully deleted"}`,
+		`{"id":"777","client_id":"1314","lhost":"lohost77","lport":"22","rhost":"","rport":"","lport_random":false,"scheme":"ssh","acl":"","usage":"ssh -p 22 rport-url.com -l ${USER}","idle_timeout_minutes":5,"rport_server":"%s"}{"status":"Tunnel successfully deleted"}`,
 		srv.URL,
 	)
 
@@ -531,7 +531,7 @@ func TestTunnelCreateWithHTTP(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"10","client_id":"1314","client_name":"","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"http","acl":"","usage":"http://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"10","client_id":"1314","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"http","acl":"","usage":"http://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 
@@ -590,7 +590,7 @@ func TestTunnelCreateWithHTTPS(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"10","client_id":"1314","client_name":"","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"https","acl":"","usage":"https://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"10","client_id":"1314","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"https","acl":"","usage":"https://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 
@@ -650,7 +650,7 @@ func TestTunnelCreateWithHTTPProxy(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"10","client_id":"1314","client_name":"","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"http","acl":"","usage":"https://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"10","client_id":"1314","lhost":"0.0.0.0","lport":"20793","rhost":"","rport":"","lport_random":false,"scheme":"http","acl":"","usage":"https://rport-url.com:20793","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 
@@ -786,7 +786,7 @@ func TestTunnelCreateWithRDP(t *testing.T) {
 	assert.Equal(t, expectedFileInput.UserName, fileWriter.FileInput.UserName)
 
 	expectedOutput := fmt.Sprintf(
-		`{"id":"777","client_id":"1314","client_name":"","lhost":"lohost77","lport":"3344","rhost":"","rport":"","lport_random":false,"scheme":"rdp","acl":"","usage":"rdp://rport-url123.com:3344","idle_timeout_minutes":5,"rport_server":"%s"}`,
+		`{"id":"777","client_id":"1314","lhost":"lohost77","lport":"3344","rhost":"","rport":"","lport_random":false,"scheme":"rdp","acl":"","usage":"rdp://rport-url123.com:3344","idle_timeout_minutes":5,"rport_server":"%s"}`,
 		srv.URL,
 	)
 	assert.Equal(t, expectedOutput, renderBuf.String())

--- a/internal/pkg/models/tunnel.go
+++ b/internal/pkg/models/tunnel.go
@@ -179,14 +179,5 @@ func (tc *TunnelCreated) KeyValues() []testing.KeyValueStr {
 		},
 	}
 
-	// Being defensive here. Clientname isn't returned but there is existing
-	// code that references it. Just in case there a dependant edge case and
-	// the client name is set, include it in the human-readable output.
-	if tc.ClientName != "" {
-		kvs = append(kvs, testing.KeyValueStr{
-			Key:   "CLIENT_NAME",
-			Value: tc.ClientName,
-		})
-	}
 	return kvs
 }

--- a/internal/pkg/models/tunnel.go
+++ b/internal/pkg/models/tunnel.go
@@ -118,7 +118,7 @@ func (t *Tunnel) KeyValues() []testing.KeyValueStr {
 type TunnelCreated struct {
 	ID              string `json:"id"`
 	ClientID        string `json:"client_id" yaml:"client_id"`
-	ClientName      string `json:"client_name" yaml:"client_name"`
+	ClientName      string `json:"client_name,omitempty" yaml:"client_name,omitempty"`
 	Lhost           string `json:"lhost" yaml:"local_host"`
 	Lport           string `json:"lport" yaml:"local_port"`
 	Rhost           string `json:"rhost" yaml:"remote_host"`
@@ -140,10 +140,6 @@ func (tc *TunnelCreated) KeyValues() []testing.KeyValueStr {
 		{
 			Key:   "CLIENT_ID",
 			Value: tc.ClientID,
-		},
-		{
-			Key:   "CLIENT_NAME",
-			Value: tc.ClientName,
 		},
 		{
 			Key:   "LOCAL_HOST",
@@ -183,5 +179,14 @@ func (tc *TunnelCreated) KeyValues() []testing.KeyValueStr {
 		},
 	}
 
+	// Being defensive here. Clientname isn't returned but there is existing
+	// code that references it. Just in case there a dependant edge case and
+	// the client name is set, include it in the human-readable output.
+	if tc.ClientName != "" {
+		kvs = append(kvs, testing.KeyValueStr{
+			Key:   "CLIENT_NAME",
+			Value: tc.ClientName,
+		})
+	}
 	return kvs
 }

--- a/internal/pkg/output/tunnel_test.go
+++ b/internal/pkg/output/tunnel_test.go
@@ -120,7 +120,6 @@ func TestRenderTunnel(t *testing.T) {
 KEY                VALUE                           
 ID:                id22                            
 CLIENT_ID:                                         
-CLIENT_NAME:                                       
 LOCAL_HOST:        lhost                           
 LOCAL_PORT:        123                             
 REMOTE_HOST:       rhost                           
@@ -135,7 +134,7 @@ USAGE:             ssh -p 123 123.22.22.33 -l root
 		},
 		{
 			Format: FormatJSON,
-			ExpectedOutput: `{"id":"id22","client_id":"","client_name":"","lhost":"lhost","lport":"123","rhost":"rhost","rport":"124","lport_random":false,"scheme":"ssh","acl":"0.0.0.0","usage":"ssh -p 123 123.22.22.33 -l root","idle_timeout_minutes":7}
+			ExpectedOutput: `{"id":"id22","client_id":"","lhost":"lhost","lport":"123","rhost":"rhost","rport":"124","lport_random":false,"scheme":"ssh","acl":"0.0.0.0","usage":"ssh -p 123 123.22.22.33 -l root","idle_timeout_minutes":7}
 `,
 			ColCountToGive: 10,
 		},
@@ -144,7 +143,6 @@ USAGE:             ssh -p 123 123.22.22.33 -l root
 			ExpectedOutput: `{
   "id": "id22",
   "client_id": "",
-  "client_name": "",
   "lhost": "lhost",
   "lport": "123",
   "rhost": "rhost",
@@ -162,7 +160,6 @@ USAGE:             ssh -p 123 123.22.22.33 -l root
 			Format: FormatYAML,
 			ExpectedOutput: `id: id22
 client_id: ""
-client_name: ""
 local_host: lhost
 local_port: "123"
 remote_host: rhost


### PR DESCRIPTION
Allow the CLI to create tunnels that use a https reverse proxy. Also hide the client name as not returned by server.