### PR TITLE
[DEV-2667] Implement OAuth for cli

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,7 +128,7 @@ issues:
         - lll
     - linters:
         - govet
-      text: "shadow: declaration of \"err\""
+      text: 'shadow: declaration of "err"'
     - path: cmd/command.go
       linters:
         - dupl
@@ -143,6 +143,7 @@ issues:
         - unparam
 
 run:
+  deadline: 2m
   skip-dirs: []
 
 # golangci.com configuration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,6 @@ linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -82,16 +81,13 @@ linters:
     - nakedret
     - noctx
     - nolintlint
-    - rowserrcheck
     - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - lll
 issues:
@@ -99,7 +95,7 @@ issues:
   exclude-rules:
     - linters:
         - gocritic
-      text: "unnecessaryDefer:"
+      text: "unnecessaryDefer:|paramTypeCombine:"
     - linters:
         - gosec
       text: "G402:|G501:|G505:|G401:"
@@ -142,6 +138,9 @@ issues:
     - path: internal/pkg/config/flags_tunnel.go
       linters:
         - funlen
+    - path: cmd/tunnel.go
+      linters:
+        - unparam
 
 run:
   skip-dirs: []

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-
 [![License](https://img.shields.io/github/license/cloudradar-monitoring/rportcli?style=for-the-badge)](https://github.com/cloudradar-monitoring/rportcli/blob/main/LICENSE)
+
 # Rport CLI (v1)
 
-Rport CLI is a tool to help you managing your remote machines connected 
+Rport CLI is a tool to help you managing your remote machines connected
 to the [rport API](https://github.com/cloudradar-monitoring/rport) directly from your terminal.
 
 The rport command line interface `rportcli` is a great addition to the rport server. Executing some tasks on the
@@ -13,7 +13,7 @@ you cannot do on the user interface.
 
 Integrates well with:
 
-![Powershell](https://img.shields.io/badge/Powershell-2CA5E0?style=for-the-badge&logo=powershell&logoColor=white) 
+![Powershell](https://img.shields.io/badge/Powershell-2CA5E0?style=for-the-badge&logo=powershell&logoColor=white)
 ![GnuBash](https://img.shields.io/badge/GNU%20Bash-4EAA25?style=for-the-badge&logo=GNU%20Bash&logoColor=white)
 ![Git](https://img.shields.io/badge/GIT-E44C30?style=for-the-badge&logo=git&logoColor=white)
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -55,7 +55,7 @@ The rportcli requires authentication with the rportd server. The CLI supports th
 
 2) Alternatively, RPORT_API_USER and RPORT_API_PASSWORD can be used (will not work with 2fa unless using the init command)'. If 2fa is enabled then the authentication will fail and either method 1) or 3) must be used.
 
-3) Using the init command to set an authentication token in the config.json file. If 2fa is enabled then the user's authentication token will be saved in a config.json. If 2fa is enabled then the user will be taken through the 2fa flow and the final authentication token will be saved in config.json. If the --oauth flag is used then the other authentication methods will be ignored and the rportcli will use an OAuth flow to obtain an authentication token. The user must follow the OAuth instructions displayed by rportcli. For detailed information on the init command, see https://cli.rport.io/.
+3) Using the init command to set an authentication token in the config.json file. If 2fa is enabled then the user's authentication token will be saved in a config.json. If 2fa is enabled then the user will be taken through the 2fa flow and the final authentication token will be saved in config.json. If the --oauth flag is used (and RPort Plus is enabled) then the other authentication methods will be ignored and the rportcli will use an OAuth flow to obtain an authentication token. The user must follow the OAuth instructions displayed by rportcli. For detailed information on the init command, see https://cli.rport.io/.
 
 `
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -30,7 +30,7 @@ var environmentVariables = `
 
 Environment Variables:
 
-The reportcli support use of the following environment variables. 
+The rportcli support use of the following environment variables.
 
 CONFIG_PATH               specify config.json file location
 CONN_TIMEOUT_SEC          set connection timeout
@@ -38,12 +38,13 @@ SESSION_VALIDITY_SECONDS  initial lifetime of interactive command session
 
 The following environment variables are used during authentication. See Server Authentication below for more info on use.
 
-RPORT_API_URL       the URL of the rportd server 
+RPORT_API_URL       the URL of the rportd server
 RPORT_API_USER      the user name for the authentication
 RPORT_API_PASSWORD  the password to be used (do not set if using an API token)'
 RPORT_API_TOKEN     your API token (will not work when RPORT_API_PASSWORD is set)
 `
 
+//nolint:lll,nolintlint
 var serverAuthentication = `
 
 Server Authentication:
@@ -54,7 +55,7 @@ The rportcli requires authentication with the rportd server. The CLI supports th
 
 2) Alternatively, RPORT_API_USER and RPORT_API_PASSWORD can be used (will not work with 2fa unless using the init command)'. If 2fa is enabled then the authentication will fail and either method 1) or 3) must be used.
 
-3) Using the init command to set an authentication token in the config.json file. If 2fa is enabled then the user's authentication token will be saved in a config.json (see readme for more information) file. If 2fa is enabled then the user will be taken through the 2fa flow and the final authentication token will be saved in config.json.
+3) Using the init command to set an authentication token in the config.json file. If 2fa is enabled then the user's authentication token will be saved in a config.json. If 2fa is enabled then the user will be taken through the 2fa flow and the final authentication token will be saved in config.json. If the --oauth flag is used then the other authentication methods will be ignored and the rportcli will use an OAuth flow to obtain an authentication token. The user must follow the OAuth instructions displayed by rportcli. For detailed information on the init command, see https://cli.rport.io/.
 
 `
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,10 +43,13 @@ var initCmd = &cobra.Command{
 
 		return manageInit(ctx, cmd)
 	},
+	//nolint: lll,nolintlint
 	Long: `
 The init command allows the user to authenticate with an rport server and cache the authentication token in a config.json file. The user will not need to re-authenticate until the token expires, at which point the init command must be run again. 
 
-If 2fa is enabled then init will take the user through the 2fa flow and save the final token. The user will not need to complete 2fa until the token expires.`,
+If 2fa is enabled then init will take the user through the 2fa flow and save the final token. The user will not need to complete 2fa until the token expires.
+
+If the --oauth flag is set and OAuth is enabled on the RPort Server (via RPort Plus), then init will take the user through the OAuth flow. As with the other methods, an RPort authentication token will be returned and cached in the config.json file. The user will not need to re-authenticate until the token expires.`,
 }
 
 func manageLogout(ctx context.Context, cmd *cobra.Command) error {
@@ -69,7 +72,8 @@ func manageInit(ctx context.Context, cmd *cobra.Command) error {
 	// when the RPORT_API_TOKEN env var is set, we shouldn't allow use of the init command
 	hasAPIToken := config.HasAPIToken()
 	if hasAPIToken {
-		return errors.New("cannot init config when the RPORT_API_TOKEN is set. If you do not wish to use the API token, please unset RPORT_API_TOKEN and use RPORT_API_USER and RPORT_API_PASSWORD instead")
+		return errors.New("cannot init config when the RPORT_API_TOKEN is set. If you do not wish to use the API token, " +
+			"please unset RPORT_API_TOKEN and use RPORT_API_USER and RPORT_API_PASSWORD instead")
 	}
 
 	promptReader := &utils.PromptReader{
@@ -123,6 +127,14 @@ func getInitRequirements() []config.ParameterRequirement {
 			Description: "Password to the rport server",
 			ShortName:   "p",
 			IsSecure:    true,
+		},
+		{
+			Field:       config.UseOAuthProvider,
+			Help:        "Use the RPort OAuth Provider (if available)",
+			Validate:    nil,
+			Description: "Use the RPort OAuth Provider (if available)",
+			ShortName:   "",
+			Type:        config.BoolRequirementType,
 		},
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,16 +3,20 @@
 The documentation system is based on [Hugo](https://gohugo.io/) and the [Geekdocs Theme](https://geekdocs.de/)
 
 ## Write
+
 Use markdown with the [shortcodes from Geekdocs](https://geekdocs.de/shortcodes/).
 
 Start a local Hugo server to get a live preview of your changes
+
 ```shell
 cd docs
 hugo server
 ```
 
 ## Check
+
 Before pushing, check your file with [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli)
+
 ```shell
 npx markdownlint-cli content/
 ```

--- a/docs/content/get-started/02-authorization.md
+++ b/docs/content/get-started/02-authorization.md
@@ -3,17 +3,22 @@ title: "Authorization"
 weight: 2
 slug: authorization
 ---
+
 {{< toc >}}
 
-You have two options to authorize the rportcli on the API of your rport server.
+You have three options to authorize the rportcli on the API of your rport server.
 
 1. Using a username, password and second factor (if applicable).
    These are the same credentials you use for the webinterface.
    A token (JWT) will be created and stored in your home directory.
-   The stored token has a limited lifetime and after the expiry you will be asked for your credentials again.  
+   The stored token has a limited lifetime and after the expiry you will be asked for your credentials again.
    This authentication method is not recommended, if you want to integrate rportcli into unattended script like
    cronjobs.
-2. Using an API token. This requires you have created API token for your user account first.
+2. Using the OAuth authentication device flow (RPort Plus Only).
+   If RPort Plus has been enabled and configured on the RPort server then rportcli can be used with OAuth.
+   This option is similar to option 1 but uses OAuth rather than a username and password.
+   See below for more information.
+3. Using an API token. This requires you have created API token for your user account first.
    The token is stored as an environment variable. No JWT is generated and no local configuration file is created.
    API tokens do not have an expiry date.
    This authentication method is suitable for unattended scripting. Store the API token securely.
@@ -38,6 +43,26 @@ You can override config path by providing an environment variable CONFIG_PATH, e
 With the environment variable `SESSION_VALIDITY_SECONDS` you can set initial lifetime of an interactive command session
 in seconds. Max value is 90 days.
 
+## by OAuth (RPort Plus only)
+
+To authorize via OAuth, execute `rportcli init --oauth`. If RPort Plus is enabled, then the cli will, via the `rportd`
+server, initiate an OAuth device flow authorization with the configured OAuth provider (one of GitHub, Microsoft
+or Google). The device flow allows the cli to authorize the user without the cli itself needing to use a
+browser. The user (who still needs to use a browser) must visit the verification URL and enter the User Code indicated.
+Both the authorization URL and the User Code are displayed by the cli. See the example below:
+
+```shell
+$ rportcli init --oauth
+Provider:       github
+Authorize URL:  https://github.com/login/device
+User Code:      C493-A983
+To sign in, use a web browser to open the page https://github.com/login/device and enter the code C493-A983 to authenticate.
+```
+
+The cli will then wait for the OAuth provider (via `rportd`) to either confirm the user's authorization or not, or
+timeout or error. Assuming no timeout or error, then the `rportd` server will return an RPort authentication token
+that will be stored in the `config.json` config file.
+
 ## by API token
 
 The easiest and most flexible way to authenticate with the rportd server is to use an API
@@ -52,14 +77,14 @@ If you have created an API token for your user account, put the following variab
 
 {{< tabs "env" >}}
 {{< tab "macOS/Linux" >}}
-    export RPORT_API_URL=<https://rport.example.com>
-    export RPORT_API_TOKEN=1234abc
-    export RPORT_API_USER=john
+export RPORT_API_URL=<https://rport.example.com>
+export RPORT_API_TOKEN=1234abc
+export RPORT_API_USER=john
 {{< /tab >}}
 {{< tab "Windows" >}}
-    $env:RPORT_API_URL="https://rport.example.com"
+$env:RPORT_API_URL="https://rport.example.com"
     $env:RPORT_API_TOKEN="1234abc"
-    $env:RPORT_API_USER="john"
+\$env:RPORT_API_USER="john"
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/internal/pkg/api/default.go
+++ b/internal/pkg/api/default.go
@@ -82,11 +82,13 @@ func (rp *Rport) GetTokenViaOAuth(ctx context.Context, tokenLifetime int) (token
 	} else {
 		fmt.Printf(loginMsg, authInfo.VerificationURI, authInfo.UserCode)
 	}
+	fmt.Print("\nWaiting for OAuth provider response ... ")
 
 	token, err = pollLogin(ctx, rp.BaseURL, loginInfo, oauth.MaxOAuthRetries)
 	if err != nil {
 		return "", err
 	}
+	fmt.Println("OK")
 
 	return token, nil
 }

--- a/internal/pkg/api/default_test.go
+++ b/internal/pkg/api/default_test.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cloudradar-monitoring/rportcli/internal/pkg/oauth"
 	"github.com/cloudradar-monitoring/rportcli/internal/pkg/utils"
 
 	"github.com/cloudradar-monitoring/rportcli/internal/pkg/models"
@@ -40,12 +42,148 @@ func TestLogin(t *testing.T) {
 	})
 
 	loginInfo, err := cl.GetToken(context.Background(), 10)
-	assert.NoError(t, err)
-	if err != nil {
+	require.NoError(t, err)
+
+	assert.Equal(t, "token123", loginInfo.Data.Token)
+}
+
+func TestLoginViaOAuth(t *testing.T) {
+	// note: the test name is used to determine test scenario
+	cases := []struct {
+		name string
+	}{
+		{
+			name: "happy_path",
+		},
+		{
+			name: "pending_retry",
+		},
+		{
+			name: "slow_retry",
+		},
+		{
+			name: "device_code_fail",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authServices := createStubAuthServicesHandler(t, tc.name)
+			defer authServices.Close()
+
+			cl := New(authServices.URL, nil)
+
+			token, err := cl.GetTokenViaOAuth(context.Background(), 10)
+			if !strings.Contains(tc.name, "fail") {
+				assert.NoError(t, err)
+				assert.Equal(t, "1234", token)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func createStubAuthServicesHandler(t *testing.T, mode string) (authServices *httptest.Server) {
+	attempts := 0
+	authServices = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inboundURL := r.URL.String()
+
+		if strings.Contains(inboundURL, "auth/provider") {
+			writeProviderInfoResponse(t, w)
+		} else if strings.Contains(inboundURL, "settings/device") {
+			writeDeviceSettingsResponse(t, w)
+		} else if strings.Contains(inboundURL, "device/login") {
+			if mode == "happy_path" {
+				writeHappyLoginResponse(t, w)
+			} else if mode == "pending_retry" {
+				attempts = handleLoginFail(t, w, attempts, "pending", http.StatusOK)
+			} else if mode == "slow_retry" {
+				attempts = handleLoginFail(t, w, attempts, "slow_down", http.StatusOK)
+			} else if mode == "device_code_fail" {
+				// no retry so don't use attempts
+				_ = handleLoginFail(t, w, 0, "bad_device_code", http.StatusBadRequest)
+			}
+		}
+	}))
+	return authServices
+}
+
+func writeProviderInfoResponse(t *testing.T, w http.ResponseWriter) {
+	expectedProviderInfoResponse := oauth.AuthProviderInfoResponse{
+		Data: oauth.AuthProviderInfo{
+			AuthProvider:      "google",
+			SettingsURI:       "/ext/oauth/settings",
+			DeviceSettingsURI: "/ext/oauth/settings/device",
+		},
+	}
+	writeExpectedResponse(t, w, http.StatusOK, expectedProviderInfoResponse)
+}
+
+func writeDeviceSettingsResponse(t *testing.T, w http.ResponseWriter) {
+	expectedLoginInfoResponse := oauth.DeviceAuthSettingsResponse{
+		Data: oauth.DeviceAuthSettings{
+			LoginInfo: oauth.DeviceLoginInfo{
+				LoginURI: "/api/v1/ext/oauth/device/login",
+				DeviceAuthInfo: &oauth.DeviceAuthInfo{
+					UserCode:        "1234",
+					DeviceCode:      "1234",
+					VerificationURI: "1234",
+					ExpiresIn:       333,
+					Interval:        1,
+					Message:         "1234",
+				},
+			},
+		},
+	}
+	writeExpectedResponse(t, w, http.StatusOK, expectedLoginInfoResponse)
+}
+
+func writeHappyLoginResponse(t *testing.T, w http.ResponseWriter) {
+	loginResponse := &oauth.DeviceLoginDetailsResponse{
+		Data: oauth.DeviceLoginDetails{
+			Token: "1234",
+		},
+	}
+	writeExpectedResponse(t, w, http.StatusOK, loginResponse)
+}
+
+func handleLoginFail(t *testing.T, w http.ResponseWriter, attempts int, failError string, statusCode int) int {
+	if attempts == 0 {
+		loginResponse := &oauth.DeviceLoginDetailsResponse{
+			Data: oauth.DeviceLoginDetails{
+				Token:     "",
+				ErrorCode: failError,
+			},
+		}
+		writeExpectedResponse(t, w, statusCode, loginResponse)
+		attempts++
+	} else {
+		loginResponse := &oauth.DeviceLoginDetailsResponse{
+			Data: oauth.DeviceLoginDetails{
+				Token: "1234",
+			},
+		}
+		writeExpectedResponse(t, w, http.StatusOK, loginResponse)
+	}
+	return attempts
+}
+
+func writeExpectedResponse(t *testing.T, w http.ResponseWriter, expectedStatusCode int, expectedResponse interface{}) {
+	t.Helper()
+
+	if expectedResponse == nil {
+		w.WriteHeader(expectedStatusCode)
 		return
 	}
 
-	assert.Equal(t, "token123", loginInfo.Data.Token)
+	jsonBytes, err := json.Marshal(expectedResponse)
+	require.NoError(t, err)
+
+	w.WriteHeader(expectedStatusCode)
+	n, err := w.Write(jsonBytes)
+
+	require.NotZero(t, n)
+	require.NoError(t, err)
 }
 
 func TestMe(t *testing.T) {

--- a/internal/pkg/api/default_test.go
+++ b/internal/pkg/api/default_test.go
@@ -151,8 +151,10 @@ func handleLoginFail(t *testing.T, w http.ResponseWriter, attempts int, failErro
 	if attempts == 0 {
 		loginResponse := &oauth.DeviceLoginDetailsResponse{
 			Data: oauth.DeviceLoginDetails{
-				Token:     "",
-				ErrorCode: failError,
+				Token:        "",
+				ErrorCode:    failError,
+				ErrorMessage: "this is the error message",
+				ErrorURI:     "https://more-err-info-here.com",
 			},
 		}
 		writeExpectedResponse(t, w, statusCode, loginResponse)

--- a/internal/pkg/api/rport.go
+++ b/internal/pkg/api/rport.go
@@ -31,7 +31,9 @@ func (rp *Rport) CallBaseClient(req *http.Request, target interface{}) (resp *ht
 	resp, err = cl.Call(req, target, &errResp)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
-			logrus.Warn("The request was unauthorized. The server might have 2FA enabled which prevents authentication by environment variable RPORT_API_PASSWORD. Try with RPORT_API_TOKEN instead. RPORT_API_USER must also be set when using RPORT_API_TOKEN.")
+			logrus.Warn("The request was unauthorized. The server might have 2FA enabled which prevents authentication " +
+				"by environment variable RPORT_API_PASSWORD. Try with RPORT_API_TOKEN instead. RPORT_API_USER must also be " +
+				"set when using RPORT_API_TOKEN.")
 		}
 		return nil, err
 	}

--- a/internal/pkg/config/load.go
+++ b/internal/pkg/config/load.go
@@ -34,6 +34,7 @@ const (
 	APIToken         = "api_token"
 	NoPrompt         = "no-prompt"
 	ReadYAML         = "read-yaml"
+	UseOAuthProvider = "oauth"
 )
 
 var (
@@ -183,6 +184,11 @@ func CollectParamsFromCommandAndPromptAndEnv(
 		if !isCorrect {
 			return nil, ErrInvalidSchemeForHTTPProxy
 		}
+	}
+
+	useOAuth := paramsSoFar.ReadBool(UseOAuthProvider, false)
+	if useOAuth {
+		return vp, nil
 	}
 
 	// if the no-prompt cli flag is set, then do not prompt for missing values

--- a/internal/pkg/config/test_helpers.go
+++ b/internal/pkg/config/test_helpers.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -64,7 +63,7 @@ func SetCLIFlagString(t *testing.T, fl *pflag.FlagSet, flagName, flagVal string)
 }
 
 func WriteTestConfigFile(t *testing.T, filePath string, rawJSON []byte) {
-	err := ioutil.WriteFile(filePath, rawJSON, 0600)
+	err := os.WriteFile(filePath, rawJSON, 0600)
 	assert.NoError(t, err)
 }
 

--- a/internal/pkg/config/write_test.go
+++ b/internal/pkg/config/write_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	options "github.com/breathbath/go_utils/v2/pkg/config"
@@ -30,7 +30,7 @@ func TestWriteConfig(t *testing.T) {
 	}
 
 	assert.FileExists(t, filePath)
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	assert.NoError(t, err)
 
 	if err != nil {

--- a/internal/pkg/controllers/scripts.go
+++ b/internal/pkg/controllers/scripts.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -67,7 +67,7 @@ func (cc *ScriptsController) ReadScriptContent(scriptsFilePath string) (scriptCo
 		return nil, fmt.Errorf("failed to read file %s: %w", scriptsFilePath, err)
 	}
 
-	scriptContent, err = ioutil.ReadAll(scriptFile)
+	scriptContent, err = io.ReadAll(scriptFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file %s: %w", scriptsFilePath, err)
 	}

--- a/internal/pkg/controllers/scripts_test.go
+++ b/internal/pkg/controllers/scripts_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -139,7 +138,7 @@ func TestScriptExecutionByClientIDsSuccess(t *testing.T) {
 			scriptPath := ""
 			if tc.shouldCreateScript {
 				scriptPath = filepath.Join(tmpDir, tc.scriptPathToGive)
-				err := ioutil.WriteFile(scriptPath, []byte(scriptToExecute), 0600)
+				err := os.WriteFile(scriptPath, []byte(scriptToExecute), 0600)
 				require.NoError(t, err)
 				writtenFiles = append(writtenFiles, scriptPath)
 			} else {

--- a/internal/pkg/oauth/oauth.go
+++ b/internal/pkg/oauth/oauth.go
@@ -124,8 +124,10 @@ func GetDeviceLogin(ctx context.Context, baseURL string, loginURI string, device
 	}
 
 	params := url.Values{
-		"device_code":    {deviceCode},
-		"token-lifetime": {strconv.Itoa(tokenLifetime)},
+		"device_code": {deviceCode},
+	}
+	if tokenLifetime != 0 {
+		params.Add("token-lifetime", strconv.Itoa(tokenLifetime))
 	}
 	loginReq.URL.RawQuery = params.Encode()
 

--- a/internal/pkg/oauth/oauth.go
+++ b/internal/pkg/oauth/oauth.go
@@ -11,7 +11,8 @@ import (
 
 const (
 	GetAuthProviderInfoURL = "/api/v1/auth/provider"
-	MaxOAuthRetries        = 20
+	MaxOAuthRetries        = 50
+	MinIntervalTime        = 10
 )
 
 // AuthProviderInfo is used to tell the client where to get info for authorizing

--- a/internal/pkg/oauth/oauth.go
+++ b/internal/pkg/oauth/oauth.go
@@ -1,0 +1,155 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	GetAuthProviderInfoURL = "/api/v1/auth/provider"
+	MaxOAuthRetries        = 20
+)
+
+// AuthProviderInfo is used to tell the client where to get info for authorizing
+type AuthProviderInfo struct {
+	AuthProvider      string `json:"auth_provider"`
+	SettingsURI       string `json:"settings_uri"`
+	DeviceSettingsURI string `json:"device_settings_uri"`
+}
+
+// AuthProviderInfoResponse is the provider info response from the server
+type AuthProviderInfoResponse struct {
+	Data AuthProviderInfo `json:"data"`
+}
+
+// DeviceAuthInfo contains info for allowing authorization of a device/cli
+type DeviceAuthInfo struct {
+	UserCode        string `json:"user_code"`
+	DeviceCode      string `json:"device_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+	Message         string `json:"message"`
+}
+
+// DeviceLoginInfo contains the auth info and which rport uri should be used for login
+type DeviceLoginInfo struct {
+	LoginURI string `json:"login_uri"`
+
+	DeviceAuthInfo *DeviceAuthInfo `json:"auth_info"`
+}
+
+// DeviceAuthSettings contains the login info and which oauth provider is being used
+type DeviceAuthSettings struct {
+	AuthProvider string          `json:"auth_provider"`
+	LoginInfo    DeviceLoginInfo `json:"details"`
+}
+
+// DeviceAuthSettingsResponse is the device auth setting/info response from the server
+type DeviceAuthSettingsResponse struct {
+	Data DeviceAuthSettings `json:"data"`
+}
+
+// DeviceLoginDetails contains the login details after a device login attempt
+type DeviceLoginDetails struct {
+	Token        string `json:"token"`
+	StatusCode   int    `json:"status_code"`
+	ErrorCode    string `json:"error"`
+	ErrorMessage string `json:"error_description"`
+	ErrorURI     string `json:"error_uri"`
+}
+
+// DeviceLoginDetailsResponse is the login details response from the server
+type DeviceLoginDetailsResponse struct {
+	Data DeviceLoginDetails `json:"data"`
+}
+
+// GetAuthProviderInfo gets the provider info from the rportd server
+func GetAuthProviderInfo(
+	ctx context.Context,
+	baseURL string) (providerInfo *AuthProviderInfo, statusCode int, err error) {
+	providerInfoRes, err := doGet(ctx, baseURL+GetAuthProviderInfoURL)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer providerInfoRes.Body.Close()
+
+	if providerInfoRes.StatusCode != http.StatusOK {
+		return nil, providerInfoRes.StatusCode, fmt.Errorf("unable to get auth provider info: %d", providerInfoRes.StatusCode)
+	}
+
+	var providerInfoResp AuthProviderInfoResponse
+	if err := json.NewDecoder(providerInfoRes.Body).Decode(&providerInfoResp); err != nil {
+		return nil, http.StatusOK, err
+	}
+
+	return &providerInfoResp.Data, http.StatusOK, nil
+}
+
+// GetDeviceAuthSettings gets the details to be used for an authorization from the server.
+func GetDeviceAuthSettings(
+	ctx context.Context,
+	baseURL string,
+	providerInfo *AuthProviderInfo,
+) (authSettings *DeviceAuthSettings, statusCode int, err error) {
+	loginInfoRes, err := doGet(ctx, baseURL+providerInfo.DeviceSettingsURI)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer loginInfoRes.Body.Close()
+
+	if loginInfoRes.StatusCode != http.StatusOK {
+		return nil, loginInfoRes.StatusCode, fmt.Errorf("unable to get auth login info: %d", loginInfoRes.StatusCode)
+	}
+
+	var loginInfoResponse DeviceAuthSettingsResponse
+	if err := json.NewDecoder(loginInfoRes.Body).Decode(&loginInfoResponse); err != nil {
+		return nil, 0, err
+	}
+
+	return &loginInfoResponse.Data, http.StatusOK, nil
+}
+
+// GetDeviceLogin will atempt to authorize with the rportd server. The login attempt may
+// fail if the user hasn't completed authorization. The login can be retried.
+func GetDeviceLogin(ctx context.Context, baseURL string, loginURI string, deviceCode string) (
+	loginResponse *DeviceLoginDetails, statusCode int, err error) {
+	loginReq, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+loginURI, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	params := url.Values{
+		"device_code": {deviceCode},
+	}
+	loginReq.URL.RawQuery = params.Encode()
+
+	loginReq.Header.Set("accept", "application/json")
+
+	loginRes, err := http.DefaultClient.Do(loginReq)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer loginRes.Body.Close()
+
+	var loginDetailsResponse DeviceLoginDetailsResponse
+	if err := json.NewDecoder(loginRes.Body).Decode(&loginDetailsResponse); err != nil {
+		return nil, loginRes.StatusCode, err
+	}
+
+	return &loginDetailsResponse.Data, loginRes.StatusCode, nil
+}
+
+// doGet is a simple GET helper function
+func doGet(ctx context.Context, targetURL string) (res *http.Response, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("accept", "application/json")
+
+	return http.DefaultClient.Do(req)
+}

--- a/internal/pkg/oauth/oauth.go
+++ b/internal/pkg/oauth/oauth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 const (
@@ -115,7 +116,7 @@ func GetDeviceAuthSettings(
 
 // GetDeviceLogin will atempt to authorize with the rportd server. The login attempt may
 // fail if the user hasn't completed authorization. The login can be retried.
-func GetDeviceLogin(ctx context.Context, baseURL string, loginURI string, deviceCode string) (
+func GetDeviceLogin(ctx context.Context, baseURL string, loginURI string, deviceCode string, tokenLifetime int) (
 	loginResponse *DeviceLoginDetails, statusCode int, err error) {
 	loginReq, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+loginURI, nil)
 	if err != nil {
@@ -123,7 +124,8 @@ func GetDeviceLogin(ctx context.Context, baseURL string, loginURI string, device
 	}
 
 	params := url.Values{
-		"device_code": {deviceCode},
+		"device_code":    {deviceCode},
+		"token-lifetime": {strconv.Itoa(tokenLifetime)},
 	}
 	loginReq.URL.RawQuery = params.Encode()
 

--- a/internal/pkg/oauth/oauth_test.go
+++ b/internal/pkg/oauth/oauth_test.go
@@ -163,6 +163,7 @@ func TestShouldLogin(t *testing.T) {
 			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, "/oauth/login/device", r.URL.EscapedPath())
 				assert.Equal(t, r.URL.Query().Get("device_code"), "123456")
+				assert.Equal(t, r.URL.Query().Get("token-lifetime"), "900")
 				writeExpectedResponse(t, w, tc.statusCode, tc.loginResponse)
 			}))
 			defer s.Close()
@@ -170,7 +171,7 @@ func TestShouldLogin(t *testing.T) {
 			ctx := context.Background()
 			cl := api.New(s.URL, nil)
 
-			loginResponse, statusCode, err := oauth.GetDeviceLogin(ctx, cl.BaseURL, "/oauth/login/device", "123456")
+			loginResponse, statusCode, err := oauth.GetDeviceLogin(ctx, cl.BaseURL, "/oauth/login/device", "123456", 900)
 
 			if statusCode == http.StatusOK {
 				require.NoError(t, err)

--- a/internal/pkg/oauth/oauth_test.go
+++ b/internal/pkg/oauth/oauth_test.go
@@ -1,0 +1,211 @@
+package oauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cloudradar-monitoring/rportcli/internal/pkg/api"
+	"github.com/cloudradar-monitoring/rportcli/internal/pkg/oauth"
+)
+
+func TestShouldGetAuthProviderInfo(t *testing.T) {
+	expectedInfoResponse := oauth.AuthProviderInfoResponse{
+		Data: oauth.AuthProviderInfo{
+			AuthProvider:      "google",
+			SettingsURI:       "/ext/oauth/settings",
+			DeviceSettingsURI: "/ext/oauth/settings/device",
+		},
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, oauth.GetAuthProviderInfoURL, r.URL.String())
+		writeExpectedResponse(t, w, http.StatusOK, expectedInfoResponse)
+	}))
+	defer s.Close()
+
+	ctx := context.Background()
+	cl := api.New(s.URL, nil)
+
+	authInfo, statusCode, err := oauth.GetAuthProviderInfo(ctx, cl.BaseURL)
+	require.NoError(t, err)
+	require.NotNil(t, authInfo)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	assert.Equal(t, expectedInfoResponse.Data.AuthProvider, authInfo.AuthProvider)
+	assert.Equal(t, expectedInfoResponse.Data.SettingsURI, authInfo.SettingsURI)
+	assert.Equal(t, expectedInfoResponse.Data.DeviceSettingsURI, authInfo.DeviceSettingsURI)
+}
+
+func TestShouldErrorWhenGetAuthProviderInfoFails(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeExpectedResponse(t, w, http.StatusInternalServerError, nil)
+	}))
+	defer s.Close()
+
+	ctx := context.Background()
+	cl := api.New(s.URL, nil)
+
+	_, statusCode, err := oauth.GetAuthProviderInfo(ctx, cl.BaseURL)
+	assert.Equal(t, http.StatusInternalServerError, statusCode)
+	assert.Error(t, err)
+}
+
+func TestShouldGetAuthSettingsInfo(t *testing.T) {
+	providerInfo := &oauth.AuthProviderInfo{
+		AuthProvider:      "google",
+		SettingsURI:       "/api/v1/ext/oauth/settings",
+		DeviceSettingsURI: "/api/v1/ext/oauth/settings/device",
+	}
+	expectedLoginInfoResponse := oauth.DeviceAuthSettingsResponse{
+		Data: oauth.DeviceAuthSettings{
+			LoginInfo: oauth.DeviceLoginInfo{
+				LoginURI: "/api/v1/ext/oauth/device/login",
+				DeviceAuthInfo: &oauth.DeviceAuthInfo{
+					UserCode:        "1234",
+					DeviceCode:      "1234",
+					VerificationURI: "1234",
+					ExpiresIn:       333,
+					Interval:        4,
+					Message:         "1234",
+				},
+			},
+		},
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, providerInfo.DeviceSettingsURI, r.URL.String())
+		writeExpectedResponse(t, w, http.StatusOK, expectedLoginInfoResponse)
+	}))
+	defer s.Close()
+
+	ctx := context.Background()
+	cl := api.New(s.URL, nil)
+
+	authSettings, statusCode, err := oauth.GetDeviceAuthSettings(ctx, cl.BaseURL, providerInfo)
+	require.NoError(t, err)
+
+	loginInfo := authSettings.LoginInfo
+	require.NotNil(t, loginInfo)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	assert.Equal(t, expectedLoginInfoResponse.Data.LoginInfo.LoginURI, loginInfo.LoginURI)
+	assert.Equal(t, expectedLoginInfoResponse.Data.LoginInfo.DeviceAuthInfo.UserCode, loginInfo.DeviceAuthInfo.UserCode)
+}
+
+func TestShouldErrorWhenGetAuthSettingsFails(t *testing.T) {
+	providerInfo := &oauth.AuthProviderInfo{
+		AuthProvider:      "google",
+		SettingsURI:       "/ext/oauth/settings",
+		DeviceSettingsURI: "/ext/oauth/settings/device",
+	}
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeExpectedResponse(t, w, http.StatusInternalServerError, nil)
+	}))
+	defer s.Close()
+
+	ctx := context.Background()
+	cl := api.New(s.URL, nil)
+
+	_, statusCode, err := oauth.GetDeviceAuthSettings(ctx, cl.BaseURL, providerInfo)
+	assert.Equal(t, http.StatusInternalServerError, statusCode)
+	assert.Error(t, err)
+}
+
+func TestShouldLogin(t *testing.T) {
+	cases := []struct {
+		name          string
+		loginResponse *oauth.DeviceLoginDetailsResponse
+		statusCode    int
+	}{
+		{
+			name: "happy path",
+			loginResponse: &oauth.DeviceLoginDetailsResponse{
+				Data: oauth.DeviceLoginDetails{
+					Token: "1234",
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
+			name: "pending error with OK status",
+			loginResponse: &oauth.DeviceLoginDetailsResponse{
+				Data: oauth.DeviceLoginDetails{
+					Token:        "",
+					ErrorCode:    "pending error",
+					ErrorMessage: "there was a pending error",
+					ErrorURI:     "http://error-uri.com",
+				},
+			},
+			statusCode: http.StatusOK,
+		},
+		{
+			name: "bad device code with not OK status",
+			loginResponse: &oauth.DeviceLoginDetailsResponse{
+				Data: oauth.DeviceLoginDetails{
+					Token:        "",
+					ErrorCode:    "bad device code error",
+					ErrorMessage: "there was a bad device code error",
+					ErrorURI:     "http://error-uri.com",
+				},
+			},
+			statusCode: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/oauth/login/device", r.URL.EscapedPath())
+				assert.Equal(t, r.URL.Query().Get("device_code"), "123456")
+				writeExpectedResponse(t, w, tc.statusCode, tc.loginResponse)
+			}))
+			defer s.Close()
+
+			ctx := context.Background()
+			cl := api.New(s.URL, nil)
+
+			loginResponse, statusCode, err := oauth.GetDeviceLogin(ctx, cl.BaseURL, "/oauth/login/device", "123456")
+
+			if statusCode == http.StatusOK {
+				require.NoError(t, err)
+				require.NotNil(t, loginResponse)
+			}
+
+			if loginResponse != nil {
+				if loginResponse.ErrorCode == "" {
+					assert.Equal(t, http.StatusOK, statusCode)
+					assert.Equal(t, tc.loginResponse.Data.Token, loginResponse.Token)
+				} else {
+					assert.Equal(t, tc.statusCode, statusCode)
+					assert.Equal(t, tc.loginResponse.Data.ErrorCode, loginResponse.ErrorCode)
+					assert.Equal(t, tc.loginResponse.Data.ErrorMessage, loginResponse.ErrorMessage)
+					assert.Equal(t, tc.loginResponse.Data.ErrorURI, loginResponse.ErrorURI)
+				}
+			}
+		})
+	}
+}
+
+func writeExpectedResponse(t *testing.T, w http.ResponseWriter, expectedStatusCode int, expectedResponse interface{}) {
+	t.Helper()
+
+	if expectedResponse == nil {
+		w.WriteHeader(expectedStatusCode)
+		return
+	}
+
+	jsonBytes, err := json.Marshal(expectedResponse)
+	require.NoError(t, err)
+
+	w.WriteHeader(expectedStatusCode)
+	n, err := w.Write(jsonBytes)
+
+	require.NotZero(t, n)
+	require.NoError(t, err)
+}

--- a/internal/pkg/output/qr.go
+++ b/internal/pkg/output/qr.go
@@ -2,11 +2,11 @@ package output
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 func GetQrImageFsWriter(namePattern string) (io.Writer, io.Closer, string, error) {
-	tempFile, err := ioutil.TempFile("", namePattern)
+	tempFile, err := os.CreateTemp("", namePattern)
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/internal/pkg/rdp/file_test.go
+++ b/internal/pkg/rdp/file_test.go
@@ -1,7 +1,6 @@
 package rdp
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestWriteRdpFile(t *testing.T) {
 		}
 	}()
 
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	assert.NoError(t, err)
 	if err != nil {
 		return

--- a/internal/pkg/utils/httpClient.go
+++ b/internal/pkg/utils/httpClient.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -63,7 +62,7 @@ func (c *BaseClient) Call(req *http.Request, target interface{}, errTarget error
 	}
 	var respBodyBytes []byte
 	if resp.StatusCode > maxValidResponseCode {
-		respBodyBytes, err = ioutil.ReadAll(resp.Body)
+		respBodyBytes, err = io.ReadAll(resp.Body)
 		if err != nil {
 			logrus.Warnf("failed to read response body: %v", err)
 			e := c.convertResponseCodeToError(resp.StatusCode)
@@ -83,7 +82,7 @@ func (c *BaseClient) Call(req *http.Request, target interface{}, errTarget error
 		return resp, nil
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err == io.EOF {
 		return resp, errors.New("no data received from command execution")
 	}


### PR DESCRIPTION
This PR adds RPort Plus - SSO/OAuth support to the `rportcli` via an OAuth device style flow where a user authorizes via a CLI presented `Verification URL` and `User Code`. The user then visits the URL and enters the User Code separately from the CLI. The CLI will then poll the OAuth provider to confirm the user's authorization.